### PR TITLE
fix: handle annotated tags in GetTags() to prevent NullReferenceException

### DIFF
--- a/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
+++ b/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
@@ -28,11 +28,12 @@ public sealed class RepositoryExtensionsTests : IDisposable
     public void GetTags_WithAnnotatedTag_ReturnsTagName()
     {
         // Arrange: one commit + one annotated tag (tag.Target is TagAnnotation, not Commit)
-        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
-        Commands.Stage(_repository, "file.txt");
         var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
-        Commit commit = _repository.Commit("Initial commit", signature, signature);
-        _repository.Tags.Add("6000.0.1f1", commit, signature, "Unity 6000.0.1f1 release");
+        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
+        _repository.Index.Add("file.txt");
+        _repository.Index.Write();
+        var commit = _repository.Commit("Initial commit", signature, signature);
+        _repository.Tags.Add("6000.0.1f1", commit.Sha, signature, "Unity 6000.0.1f1 release");
 
         // Act
         IEnumerable<string> tags = _repository.GetTags();

--- a/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
+++ b/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using LibGit2Sharp;
 
 namespace UnityXrefMaps.Tests;
@@ -40,6 +41,59 @@ public sealed class RepositoryExtensionsTests : IDisposable
 
         // Assert
         Assert.Contains("6000.0.1f1", tags);
+    }
+
+    [Fact]
+    public void GetTags_WithLightweightTag_ReturnsTagName()
+    {
+        // Arrange: lightweight tag (tag.Target is the Commit directly, while-loop never iterates)
+        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
+        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
+        _repository.Index.Add("file.txt");
+        _repository.Index.Write();
+        var commit = _repository.Commit("Initial commit", signature, signature);
+        _repository.Tags.Add("2023.1.0f1", commit);
+
+        // Act
+        IEnumerable<string> tags = _repository.GetTags();
+
+        // Assert
+        Assert.Contains("2023.1.0f1", tags);
+    }
+
+    [Fact]
+    public void GetTags_WithNestedAnnotatedTag_ReturnsTagName()
+    {
+        // Arrange: outer annotated tag → inner TagAnnotation → Commit (while-loop iterates twice)
+        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
+        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
+        _repository.Index.Add("file.txt");
+        _repository.Index.Write();
+        var commit = _repository.Commit("Initial commit", signature, signature);
+        var innerTag = _repository.Tags.Add("inner", commit.Sha, signature, "Inner annotated tag");
+        _repository.Tags.Add("outer", innerTag.Target.Sha, signature, "Outer tag pointing to inner annotation");
+
+        // Act
+        IEnumerable<string> tags = _repository.GetTags();
+
+        // Assert
+        Assert.Contains("outer", tags);
+    }
+
+    [Fact]
+    public void GetTags_WithTagNotPointingToCommit_IsStillReturned()
+    {
+        // Arrange: tag pointing to a blob (not a Commit); GetTaggedCommit returns null,
+        // so the tag sorts last with DateTimeOffset.MinValue but still appears in output.
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("blob content"));
+        var blob = _repository.ObjectDatabase.CreateBlob(stream);
+        _repository.Tags.Add("blob-tag", blob);
+
+        // Act
+        IEnumerable<string> tags = _repository.GetTags();
+
+        // Assert
+        Assert.Contains("blob-tag", tags);
     }
 
     public void Dispose()

--- a/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
+++ b/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
@@ -29,7 +29,7 @@ public sealed class RepositoryExtensionsTests : IDisposable
     {
         // Arrange: one commit + one annotated tag (tag.Target is TagAnnotation, not Commit)
         File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
-        Commands.Stage(_repository, "*");
+        Commands.Stage(_repository, "file.txt");
         var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
         Commit commit = _repository.Commit("Initial commit", signature, signature);
         _repository.Tags.Add("6000.0.1f1", commit, signature, "Unity 6000.0.1f1 release");

--- a/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
+++ b/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
@@ -28,77 +28,56 @@ public sealed class RepositoryExtensionsTests : IDisposable
     [Fact]
     public void GetTags_WithAnnotatedTag_ReturnsTagName()
     {
-        // Arrange: one commit + one annotated tag (tag.Target is TagAnnotation, not Commit)
-        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
-        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
-        _repository.Index.Add("file.txt");
-        _repository.Index.Write();
-        var commit = _repository.Commit("Initial commit", signature, signature);
+        var (commit, signature) = CreateCommit();
         _repository.Tags.Add("6000.0.1f1", commit.Sha, signature, "Unity 6000.0.1f1 release");
 
-        // Act
-        IEnumerable<string> tags = _repository.GetTags();
-
-        // Assert
-        Assert.Contains("6000.0.1f1", tags);
+        Assert.Contains("6000.0.1f1", _repository.GetTags());
     }
 
     [Fact]
     public void GetTags_WithLightweightTag_ReturnsTagName()
     {
-        // Arrange: lightweight tag (tag.Target is the Commit directly, while-loop never iterates)
-        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
-        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
-        _repository.Index.Add("file.txt");
-        _repository.Index.Write();
-        var commit = _repository.Commit("Initial commit", signature, signature);
+        // tag.Target is the Commit directly; while-loop in GetTaggedCommit never iterates
+        var (commit, _) = CreateCommit();
         _repository.Tags.Add("2023.1.0f1", commit);
 
-        // Act
-        IEnumerable<string> tags = _repository.GetTags();
-
-        // Assert
-        Assert.Contains("2023.1.0f1", tags);
+        Assert.Contains("2023.1.0f1", _repository.GetTags());
     }
 
     [Fact]
     public void GetTags_WithNestedAnnotatedTag_ReturnsTagName()
     {
-        // Arrange: outer annotated tag → inner TagAnnotation → Commit (while-loop iterates twice)
-        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
-        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
-        _repository.Index.Add("file.txt");
-        _repository.Index.Write();
-        var commit = _repository.Commit("Initial commit", signature, signature);
+        // outer annotated tag → inner TagAnnotation → Commit; while-loop iterates twice
+        var (commit, signature) = CreateCommit();
         var innerTag = _repository.Tags.Add("inner", commit.Sha, signature, "Inner annotated tag");
         _repository.Tags.Add("outer", innerTag.Target.Sha, signature, "Outer tag pointing to inner annotation");
 
-        // Act
-        IEnumerable<string> tags = _repository.GetTags();
-
-        // Assert
-        Assert.Contains("outer", tags);
+        Assert.Contains("outer", _repository.GetTags());
     }
 
     [Fact]
     public void GetTags_WithTagNotPointingToCommit_IsStillReturned()
     {
-        // Arrange: tag pointing to a blob (not a Commit); GetTaggedCommit returns null,
-        // so the tag sorts last with DateTimeOffset.MinValue but still appears in output.
+        // GetTaggedCommit returns null for a blob target; tag sorts last but still appears in output
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes("blob content"));
         var blob = _repository.ObjectDatabase.CreateBlob(stream);
         _repository.Tags.Add("blob-tag", blob);
 
-        // Act
-        IEnumerable<string> tags = _repository.GetTags();
-
-        // Assert
-        Assert.Contains("blob-tag", tags);
+        Assert.Contains("blob-tag", _repository.GetTags());
     }
 
     public void Dispose()
     {
         _repository.Dispose();
         try { Directory.Delete(_tempPath, recursive: true); } catch { }
+    }
+
+    private (Commit commit, Signature signature) CreateCommit()
+    {
+        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
+        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
+        _repository.Index.Add("file.txt");
+        _repository.Index.Write();
+        return (_repository.Commit("Initial commit", signature, signature), signature);
     }
 }

--- a/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
+++ b/UnityXrefMaps.Tests/RepositoryExtensionsTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using LibGit2Sharp;
+
+namespace UnityXrefMaps.Tests;
+
+public sealed class RepositoryExtensionsTests : IDisposable
+{
+    private readonly string _tempPath;
+    private readonly Repository _repository;
+
+    public RepositoryExtensionsTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempPath);
+        Repository.Init(_tempPath);
+        _repository = new Repository(_tempPath);
+    }
+
+    /// <summary>
+    /// Annotated tags (created with a message) have a TagAnnotation as their Target, not a Commit.
+    /// GetTags() was casting Target directly to Commit via (tag.Target as Commit)!, which returned
+    /// null for annotated tags and then threw NullReferenceException on .Author.When.
+    /// Unity's UnityCsReference repository uses annotated tags.
+    /// </summary>
+    [Fact]
+    public void GetTags_WithAnnotatedTag_ReturnsTagName()
+    {
+        // Arrange: one commit + one annotated tag (tag.Target is TagAnnotation, not Commit)
+        File.WriteAllText(Path.Combine(_tempPath, "file.txt"), "content");
+        Commands.Stage(_repository, "*");
+        var signature = new Signature("test", "test@test.com", DateTimeOffset.UtcNow);
+        Commit commit = _repository.Commit("Initial commit", signature, signature);
+        _repository.Tags.Add("6000.0.1f1", commit, signature, "Unity 6000.0.1f1 release");
+
+        // Act
+        IEnumerable<string> tags = _repository.GetTags();
+
+        // Assert
+        Assert.Contains("6000.0.1f1", tags);
+    }
+
+    public void Dispose()
+    {
+        _repository.Dispose();
+        try { Directory.Delete(_tempPath, recursive: true); } catch { }
+    }
+}

--- a/UnityXrefMaps.Tests/UnityXrefMaps.Tests.csproj
+++ b/UnityXrefMaps.Tests/UnityXrefMaps.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UnityXrefMaps/RepositoryExtensions.cs
+++ b/UnityXrefMaps/RepositoryExtensions.cs
@@ -20,8 +20,18 @@ internal static partial class RepositoryExtensions
     public static IEnumerable<string> GetTags(this Repository repository)
     {
         return repository.Tags
-            .OrderByDescending(tag => (tag.Target as Commit)!.Author.When)
+            .OrderByDescending(tag => GetTaggedCommit(tag)?.Author.When ?? DateTimeOffset.MinValue)
             .Select(tag => tag.FriendlyName);
+    }
+
+    // Lightweight tags point directly to a Commit; annotated tags point to a TagAnnotation
+    // whose own Target is the Commit (possibly through multiple layers of annotation).
+    private static Commit? GetTaggedCommit(Tag tag)
+    {
+        GitObject target = tag.Target;
+        while (target is TagAnnotation annotation)
+            target = annotation.Target;
+        return target as Commit;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- `GetTags()` crashed with `NullReferenceException` when the repository contained annotated tags (created with `git tag -a`). It cast `tag.Target` directly to `Commit` using the null-forgiving operator `!`, but for annotated tags `tag.Target` is a `TagAnnotation`, not a `Commit`, so the cast silently returned `null` and the subsequent `.Author.When` access threw.
- Unity's `UnityCsReference` repository uses annotated tags exclusively, so `GetLatestVersions()` — and therefore the entire tool — always crashed at startup.
- Fixed by extracting `GetTaggedCommit(Tag)`, which peels through the `TagAnnotation` chain with a `while` loop until it reaches the underlying `Commit` (or returns `null` for non-commit targets, falling back to `DateTimeOffset.MinValue` for sorting).

## Test plan

- [x] `GetTags_WithAnnotatedTag_ReturnsTagName` — regression test: annotated tag must appear in results without throwing
- [x] `GetTags_WithLightweightTag_ReturnsTagName` — lightweight tag (`tag.Target` is `Commit` directly, `while`-loop never iterates)
- [x] `GetTags_WithNestedAnnotatedTag_ReturnsTagName` — outer `TagAnnotation` → inner `TagAnnotation` → `Commit` (loop iterates twice, multi-level peeling)
- [x] `GetTags_WithTagNotPointingToCommit_IsStillReturned` — tag pointing to a blob; `GetTaggedCommit` returns `null`, tag still appears in output sorted last

https://claude.ai/code/session_01WNaTJnpDwNjqyfL1uhYqJ4