### PR TITLE
fix: prevent crash in XRefHrefFixer when a method or property name is not found

### DIFF
--- a/UnityXrefMaps.Tests/XRefHrefFixerTests.cs
+++ b/UnityXrefMaps.Tests/XRefHrefFixerTests.cs
@@ -72,5 +72,76 @@ namespace UnityXrefMaps.Tests
 
             Assert.Equal(expected, XRefHrefFixer.Fix(apiUrl, xrefMapReference, Array.Empty<string>(), true));
         }
+
+        /// <summary>
+        /// The regex that extracts the bare method name requires a '(' character to match.
+        /// When the display name has no parentheses — e.g. Name = "MyMethod" — the regex
+        /// fails, producing an empty string. The code then called uid.Substring(0, -1),
+        /// which throws ArgumentOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void Fix_PackageMethodWithNoParenthesesInName_DoesNotThrow()
+        {
+            XrefMapReference xrefMapReference = new()
+            {
+                CommentId = "M:MyNamespace.MyClass.MyMethod",
+                Name = "MyMethod",
+            };
+
+            string result = XRefHrefFixer.Fix(
+                "https://docs.unity3d.com/Packages/test@1.0/api/",
+                xrefMapReference,
+                Array.Empty<string>(),
+                isPackage: true);
+
+            Assert.StartsWith("https://docs.unity3d.com/Packages/test@1.0/api/", result);
+        }
+
+        /// <summary>
+        /// When the method name extracted from the display name — e.g. "DifferentMethod" from
+        /// "DifferentMethod()" — does not appear in the uid, e.g.
+        /// "MyNamespace.MyClass.ActualMethod", IndexOf returns -1. The code then called
+        /// uid.Substring(0, -2), which throws ArgumentOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void Fix_PackageMethodNameAbsentFromUid_DoesNotThrow()
+        {
+            XrefMapReference xrefMapReference = new()
+            {
+                CommentId = "M:MyNamespace.MyClass.ActualMethod",
+                Name = "DifferentMethod()",
+            };
+
+            string result = XRefHrefFixer.Fix(
+                "https://docs.unity3d.com/Packages/test@1.0/api/",
+                xrefMapReference,
+                Array.Empty<string>(),
+                isPackage: true);
+
+            Assert.StartsWith("https://docs.unity3d.com/Packages/test@1.0/api/", result);
+        }
+
+        /// <summary>
+        /// When the property name — e.g. "DifferentProperty" — does not appear in the uid,
+        /// e.g. "MyNamespace.MyClass.ActualProperty", IndexOf returns -1. The code then called
+        /// uid.Substring(0, -2), which throws ArgumentOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void Fix_PackagePropertyNameAbsentFromUid_DoesNotThrow()
+        {
+            XrefMapReference xrefMapReference = new()
+            {
+                CommentId = "P:MyNamespace.MyClass.ActualProperty",
+                Name = "DifferentProperty",
+            };
+
+            string result = XRefHrefFixer.Fix(
+                "https://docs.unity3d.com/Packages/test@1.0/api/",
+                xrefMapReference,
+                Array.Empty<string>(),
+                isPackage: true);
+
+            Assert.StartsWith("https://docs.unity3d.com/Packages/test@1.0/api/", result);
+        }
     }
 }

--- a/UnityXrefMaps/XRefHrefFixer.cs
+++ b/UnityXrefMaps/XRefHrefFixer.cs
@@ -39,15 +39,30 @@ namespace UnityXrefMaps
                 case "M":
                     Match methodNameMatch = MethodNameRegex().Match(name);
 
-                    string methodName = name.Substring(0, methodNameMatch.Groups[1].Value.Length);
+                    // regex requires '(' — fall back to the full name when it does not match
+                    string methodName = methodNameMatch.Success
+                        ? name.Substring(0, methodNameMatch.Groups[1].Value.Length)
+                        : name;
 
-                    classFullName = uid.Substring(0, uid.IndexOf(methodName) - 1);
+                    int methodIdx = uid.IndexOf(methodName);
+                    if (methodIdx < 0)
+                    {
+                        return $"{apiUrl}{NonWordCharRegex().Replace(uid, "_")}.html";
+                    }
+
+                    classFullName = uid.Substring(0, methodIdx - 1);
 
                     return $"{apiUrl}{classFullName}.html#{NonWordCharRegex().Replace(uid, "_")}";
                 case "P":
                 case "F":
                 default:
-                    classFullName = uid.Substring(0, uid.IndexOf(name) - 1);
+                    int nameIdx = uid.IndexOf(name);
+                    if (nameIdx < 0)
+                    {
+                        return $"{apiUrl}{NonWordCharRegex().Replace(uid, "_")}.html";
+                    }
+
+                    classFullName = uid.Substring(0, nameIdx - 1);
 
                     return $"{apiUrl}{classFullName}.html#{NonWordCharRegex().Replace(uid, "_")}";
             }


### PR DESCRIPTION
## Summary

Two crashes in `XRefHrefFixer.FixPackage()` that occur with certain API members in Unity packages.

### Method name has no parentheses

**Problem:** When building the href for a method, the code runs a regex to strip generic arguments from the display name and extract just the method name. The regex requires a `(` character to match. When the display name has no parentheses — for example `Name = "MyMethod"` instead of `"MyMethod()"` — the regex fails and returns an empty string. The code then called `uid.IndexOf("")`, which always returns `0`, and then `uid.Substring(0, 0 - 1)` = `uid.Substring(0, -1)`, which throws `ArgumentOutOfRangeException`.

**Fix:** When the regex does not match, use the full display name directly instead of the empty string.

### Method or property name not found in the uid

**Problem:** After extracting the method name, the code looks for it inside the `uid` string with `IndexOf`. If the extracted name does not appear in the uid — for example when the display name is `"DifferentMethod()"` but the uid is `"MyNamespace.MyClass.ActualMethod"` — `IndexOf` returns `-1`. The code then called `uid.Substring(0, -1 - 1)` = `uid.Substring(0, -2)`, which throws `ArgumentOutOfRangeException`. The same crash happens with properties and fields.

**Fix:** Check the result of `IndexOf` before calling `Substring`. When the name is not found, fall back to using the full `uid` with special characters replaced by underscores.

## Tests

- `Fix_PackageMethodWithNoParenthesesInName_DoesNotThrow` — method with no `(` in its name must not throw
- `Fix_PackageMethodNameAbsentFromUid_DoesNotThrow` — method name not found in uid must not throw
- `Fix_PackagePropertyNameAbsentFromUid_DoesNotThrow` — property name not found in uid must not throw

PR #9 contains just the tests without the fix to confirm CI goes red; this PR (with the fix applied) should go green.

https://claude.ai/code/session_01WNaTJnpDwNjqyfL1uhYqJ4