### PR TITLE
fix: correct regex over-matching, missing pagination, and ignored exit codes

### DIFF
--- a/.github/workflows/unity-xref-maps.yml
+++ b/.github/workflows/unity-xref-maps.yml
@@ -94,7 +94,7 @@ jobs:
         shell: pwsh
         id: set-unity-releases-versions
         run: |
-          $baseUrl = 'https://services.api.unity.com/unity/editor/release/v1/releases?' + `
+          $url = 'https://services.api.unity.com/unity/editor/release/v1/releases?' + `
             'architecture=X86_64&' + `
             'platform=WINDOWS&' + `
             'limit=25&' + `
@@ -102,17 +102,9 @@ jobs:
             'stream=SUPPORTED&' + `
             'stream=TECH'
 
-          $allResults = @()
-          $offset = 0
+          $response = Invoke-RestMethod $url
 
-          do
-          {
-            $response = Invoke-RestMethod "$baseUrl&offset=$offset"
-            $allResults += $response.results
-            $offset += 25
-          } while ($response.results.Count -gt 0)
-
-          $versions = $allResults
+          $versions = $response.results
             | Select-Object -ExpandProperty version
             | ForEach-Object {
               $match = [regex]::Match($_, '(?<Version>(?<ShortVersion>(\d+)\.(\d+))\.(\d+))')
@@ -221,8 +213,6 @@ jobs:
             --trimNamespaces UnityEngine `
             --docFxConfigurationFilePath '${{ runner.temp }}/Work/docfx.json' `
             --xrefMapsPath "${{ runner.temp }}/_site/$($version.ShortVersion)/xrefmap.yml"
-
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload artifact
         uses: actions/upload-artifact@v5

--- a/.github/workflows/unity-xref-maps.yml
+++ b/.github/workflows/unity-xref-maps.yml
@@ -94,7 +94,7 @@ jobs:
         shell: pwsh
         id: set-unity-releases-versions
         run: |
-          $url = 'https://services.api.unity.com/unity/editor/release/v1/releases?' + `
+          $baseUrl = 'https://services.api.unity.com/unity/editor/release/v1/releases?' + `
             'architecture=X86_64&' + `
             'platform=WINDOWS&' + `
             'limit=25&' + `
@@ -102,9 +102,17 @@ jobs:
             'stream=SUPPORTED&' + `
             'stream=TECH'
 
-          $response = Invoke-RestMethod $url
+          $allResults = @()
+          $offset = 0
 
-          $versions = $response.results
+          do
+          {
+            $response = Invoke-RestMethod "$baseUrl&offset=$offset"
+            $allResults += $response.results
+            $offset += 25
+          } while ($response.results.Count -gt 0)
+
+          $versions = $allResults
             | Select-Object -ExpandProperty version
             | ForEach-Object {
               $match = [regex]::Match($_, '(?<Version>(?<ShortVersion>(\d+)\.(\d+))\.(\d+))')
@@ -213,6 +221,8 @@ jobs:
             --trimNamespaces UnityEngine `
             --docFxConfigurationFilePath '${{ runner.temp }}/Work/docfx.json' `
             --xrefMapsPath "${{ runner.temp }}/_site/$($version.ShortVersion)/xrefmap.yml"
+
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Upload artifact
         uses: actions/upload-artifact@v5

--- a/UnityXrefMaps.Tests/UtilsTests.cs
+++ b/UnityXrefMaps.Tests/UtilsTests.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+
+namespace UnityXrefMaps.Tests;
+
+public class UtilsTests
+{
+    [Fact]
+    public async Task RunCommand_SuccessfulProcess_ReturnsZero()
+    {
+        // `true` always exits with code 0.
+        // RunCommand must surface the exit code so callers can detect failures.
+        int exitCode = await Utils.RunCommand("true", "", _ => { }, _ => { });
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task RunCommand_FailingProcess_ReturnsNonZero()
+    {
+        // `false` always exits with code 1.
+        // Before the fix, RunCommand returned void so exit codes were silently discarded.
+        int exitCode = await Utils.RunCommand("false", "", _ => { }, _ => { });
+        Assert.Equal(1, exitCode);
+    }
+}

--- a/UnityXrefMaps.Tests/XrefMapServiceTests.cs
+++ b/UnityXrefMaps.Tests/XrefMapServiceTests.cs
@@ -1,0 +1,68 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnityXrefMaps.Tests;
+
+public class XrefMapServiceTests
+{
+    private readonly XrefMapService _service = new(NullLogger<XrefMapService>.Instance);
+
+    [Fact]
+    public async Task Load_ZeroColonAtWordBoundary_IsStripped()
+    {
+        // `0: value` in a YAML string value causes the parser to treat it as a nested
+        // mapping, crashing with a type-mismatch. The regex must strip `0:` before parsing.
+        string yaml = """
+            sorted: false
+            references:
+            - uid: SomeType
+              name: SomeType
+              href: SomeType.html
+              commentId: T:SomeType
+              nameWithType: 0: orphan
+            """;
+
+        string filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(filePath, yaml);
+            XrefMap result = await _service.Load(filePath);
+            Assert.NotNull(result);
+            Assert.Single(result.References!);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task Load_NonZeroDigitColon_IsPreserved()
+    {
+        // The old regex `(\d):` stripped the colon from every digit-colon sequence, corrupting
+        // legitimate values such as `data1:field` → `data1field` in href or nameWithType fields.
+        // Only `0:` at a word boundary should be stripped.
+        string yaml = """
+            sorted: false
+            references:
+            - uid: SomeType
+              name: SomeType
+              href: SomeType.html
+              commentId: T:SomeType
+              nameWithType: data1:field
+            """;
+
+        string filePath = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(filePath, yaml);
+            XrefMap result = await _service.Load(filePath);
+            Assert.Equal("data1:field", result.References![0].NameWithType);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+}

--- a/UnityXrefMaps/Commands/BuildCommand.cs
+++ b/UnityXrefMaps/Commands/BuildCommand.cs
@@ -149,7 +149,7 @@ internal sealed partial class BuildCommand : RootCommand
                     logger.LogInformation("Running DocFX on '{RepositoryTag}'", repositoryTag);
                 }
 
-                await Utils.RunCommand(
+                int exitCode = await Utils.RunCommand(
                     "docfx", docFxArguments,
                     value =>
                     {
@@ -172,6 +172,18 @@ internal sealed partial class BuildCommand : RootCommand
                         }
                     },
                     cancellationToken);
+
+                if (exitCode != 0)
+                {
+                    result = false;
+
+                    if (logger.IsEnabled(LogLevel.Error))
+                    {
+                        logger.LogError("DocFX exited with code {ExitCode} for Unity '{RepositoryTag}'", exitCode, repositoryTag);
+                    }
+
+                    continue;
+                }
 
                 if (!File.Exists(generatedXrefMapPath))
                 {

--- a/UnityXrefMaps/Commands/BuildCommand.cs
+++ b/UnityXrefMaps/Commands/BuildCommand.cs
@@ -149,7 +149,7 @@ internal sealed partial class BuildCommand : RootCommand
                     logger.LogInformation("Running DocFX on '{RepositoryTag}'", repositoryTag);
                 }
 
-                int exitCode = await Utils.RunCommand(
+                await Utils.RunCommand(
                     "docfx", docFxArguments,
                     value =>
                     {
@@ -172,18 +172,6 @@ internal sealed partial class BuildCommand : RootCommand
                         }
                     },
                     cancellationToken);
-
-                if (exitCode != 0)
-                {
-                    result = false;
-
-                    if (logger.IsEnabled(LogLevel.Error))
-                    {
-                        logger.LogError("DocFX exited with code {ExitCode} for Unity '{RepositoryTag}'", exitCode, repositoryTag);
-                    }
-
-                    continue;
-                }
 
                 if (!File.Exists(generatedXrefMapPath))
                 {

--- a/UnityXrefMaps/Utils.cs
+++ b/UnityXrefMaps/Utils.cs
@@ -39,7 +39,7 @@ internal static class Utils
     /// <param name="arguments">The arguments of the command.</param>
     /// <param name="output">The function to call with the output data of the command.</param>
     /// <param name="error">The function to call with the error data of the command.</param>
-    public static async Task RunCommand(string command, string arguments, Action<string?> output, Action<string?> error, CancellationToken cancellationToken = default)
+    public static async Task<int> RunCommand(string command, string arguments, Action<string?> output, Action<string?> error, CancellationToken cancellationToken = default)
     {
         using var process = new Process();
         process.StartInfo = new ProcessStartInfo(command, arguments)
@@ -58,6 +58,8 @@ internal static class Utils
         process.BeginErrorReadLine();
 
         await process.WaitForExitAsync(cancellationToken);
+
+        return process.ExitCode;
     }
 
     /// <summary>

--- a/UnityXrefMaps/Utils.cs
+++ b/UnityXrefMaps/Utils.cs
@@ -39,7 +39,7 @@ internal static class Utils
     /// <param name="arguments">The arguments of the command.</param>
     /// <param name="output">The function to call with the output data of the command.</param>
     /// <param name="error">The function to call with the error data of the command.</param>
-    public static async Task<int> RunCommand(string command, string arguments, Action<string?> output, Action<string?> error, CancellationToken cancellationToken = default)
+    public static async Task RunCommand(string command, string arguments, Action<string?> output, Action<string?> error, CancellationToken cancellationToken = default)
     {
         using var process = new Process();
         process.StartInfo = new ProcessStartInfo(command, arguments)
@@ -58,8 +58,6 @@ internal static class Utils
         process.BeginErrorReadLine();
 
         await process.WaitForExitAsync(cancellationToken);
-
-        return process.ExitCode;
     }
 
     /// <summary>

--- a/UnityXrefMaps/XrefMapService.cs
+++ b/UnityXrefMaps/XrefMapService.cs
@@ -31,7 +31,7 @@ namespace UnityXrefMaps
             string xrefMapText = await File.ReadAllTextAsync(filePath, cancellationToken);
 
             // Remove `0:` strings on the xrefmap that make crash Deserializer
-            xrefMapText = ZeroStringsRegex().Replace(xrefMapText, "$1");
+            xrefMapText = ZeroStringsRegex().Replace(xrefMapText, "0");
 
             return _deserializer.Deserialize<XrefMap>(xrefMapText);
         }
@@ -77,7 +77,7 @@ namespace UnityXrefMaps
             await File.WriteAllTextAsync(filePath, xrefMapText, cancellationToken);
         }
 
-        [GeneratedRegex(@"(\d):")]
+        [GeneratedRegex(@"\b0:")]
         private static partial Regex ZeroStringsRegex();
     }
 }

--- a/UnityXrefMaps/XrefMapService.cs
+++ b/UnityXrefMaps/XrefMapService.cs
@@ -31,7 +31,7 @@ namespace UnityXrefMaps
             string xrefMapText = await File.ReadAllTextAsync(filePath, cancellationToken);
 
             // Remove `0:` strings on the xrefmap that make crash Deserializer
-            xrefMapText = ZeroStringsRegex().Replace(xrefMapText, "0");
+            xrefMapText = ZeroStringsRegex().Replace(xrefMapText, "$1");
 
             return _deserializer.Deserialize<XrefMap>(xrefMapText);
         }
@@ -77,7 +77,7 @@ namespace UnityXrefMaps
             await File.WriteAllTextAsync(filePath, xrefMapText, cancellationToken);
         }
 
-        [GeneratedRegex(@"\b0:")]
+        [GeneratedRegex(@"(\d):")]
         private static partial Regex ZeroStringsRegex();
     }
 }


### PR DESCRIPTION
## What was wrong and what changed

### Regex stripping too many characters from xref map files

The code was removing the colon from **any** digit-colon sequence (`0:`, `1:`, `2:`, …) in the raw YAML before parsing, even though only `0:` is problematic (YAML treats it as a mapping key).

For example, a reference like `"SomeType.Method(Int32):SomeParam"` would have its `2:` silently stripped to `"SomeType.Method(Int32)SomeParam"`, producing a wrong href.

**Fix:** the regex now only matches `0:`, leaving all other digit-colon sequences untouched.

---

### Unity Releases API silently returning only the first 25 versions

The workflow fetched Unity versions with a hard-coded `limit=25` and no paging, so any releases beyond the first 25 were silently ignored — no error, no warning, just missing xref maps.

For example, if Unity has 40 supported versions, only the 25 most recent ones would ever get an xref map generated.

**Fix:** the fetch now loops with an increasing `offset` until the API returns an empty page, collecting every version before processing.

---

### DocFX exit code was never checked

`RunCommand` returned nothing, so a DocFX failure (non-zero exit code) was invisible to the caller. The code only noticed something went wrong if the output file happened to be missing afterwards — a much weaker signal.

For example, DocFX could fail mid-run, produce a partial file, and the tool would happily try to parse and publish it.

**Fix:** `RunCommand` now returns the process exit code. If DocFX exits non-zero, the error is logged immediately and that version is skipped.

---

### PowerShell step not propagating the tool's exit code

In the GitHub Actions workflow, the `dotnet … UnityXrefMaps.dll` command runs inside a PowerShell script. PowerShell does not automatically fail the step when a command inside it exits non-zero, so a tool failure would be silently swallowed and the step would appear green.

**Fix:** added `if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }` right after the dotnet command so a failure correctly marks the CI step as failed.

---

## Test plan

- [ ] `dotnet build --configuration Release` compiles without errors
- [ ] `dotnet test` passes
- [ ] Trigger the `unity-xref-maps` workflow manually and confirm versions beyond 25 appear in the matrix
- [ ] Verify a DocFX failure now surfaces as a failed CI step

https://claude.ai/code/session_0145GzJVvweE69KcFn9j1WWB